### PR TITLE
Update video_viewer.dart

### DIFF
--- a/lib/video_viewer.dart
+++ b/lib/video_viewer.dart
@@ -147,6 +147,9 @@ class VideoViewerState extends State<VideoViewer> {
     _controller.looping = widget.looping;
     _controller.isShowingThumbnail = _style.thumbnail != null;
     await _controller.initialize(widget.source, autoPlay: widget.autoPlay);
+    
+    if (!mounted) return;
+    
     setState(() => _initialized = true);
   }
 


### PR DESCRIPTION
Added if (!mounted) return; in _initVideoViewer to avoid "setState() called after dispose(): VideoViewerState#64324(lifecycle state: defunct, not mounted)" error.